### PR TITLE
Add Google Analytics tracking

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,6 +8,12 @@ app.set('views', __dirname + '/views');
 
 app.use(express.static('assets'));
 
+// pass GA tracking code to all templates
+app.use(function(req, res, next){
+  res.locals.GOOGLE_ANALYTICS_TRACKING_ID = process.env.GOOGLE_ANALYTICS_TRACKING_ID;
+  next();
+});
+
 nunjucks.setup({
   autoescape: true,
   watch: true,

--- a/views/_includes/google-analytics.html
+++ b/views/_includes/google-analytics.html
@@ -1,0 +1,9 @@
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+  ga('create', '{{ GOOGLE_ANALYTICS_TRACKING_ID }}', 'auto');
+  ga('send', 'pageview');
+</script>

--- a/views/_layouts/_layout-default.html
+++ b/views/_layouts/_layout-default.html
@@ -22,5 +22,9 @@
 
 {% include "_includes/footer-global.html" %}
 
+{% if GOOGLE_ANALYTICS_TRACKING_ID %}
+  {% include "_includes/google-analytics.html" %}
+{% endif %}
+
 </body>
 </html>


### PR DESCRIPTION
If the GOOGLE_ANALYTICS_TRACKING_ID environment variable is set, include tracking code with the given ID at the end of the page.
