### PR TITLE
Add tint and shade scss functions

### DIFF
--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -1,5 +1,6 @@
 @import "tools/contain-floats";
 @import "tools/media-queries";
+@import "tools/tints";
 
 @import "variables/colours";
 //@import "variables/lato"; // hot swappable type

--- a/assets/scss/tools/_tints.scss
+++ b/assets/scss/tools/_tints.scss
@@ -1,0 +1,17 @@
+/// Slightly lighten a color
+/// @access public
+/// @param {Color} $color - color to tint
+/// @param {Number} $percentage - percentage of `$color` in returned color
+/// @return {Color}
+@function tint($color, $percentage) {
+  @return mix(white, $color, $percentage);
+}
+
+/// Slightly darken a color
+/// @access public
+/// @param {Color} $color - color to shade
+/// @param {Number} $percentage - percentage of `$color` in returned color
+/// @return {Color}
+@function shade($color, $percentage) {
+  @return mix(black, $color, $percentage);
+}


### PR DESCRIPTION
2 little Sass functions to let us tint and shade palette colours.

For example, "I want 10% NHS Blue please"

```
.foo {
  color: tint($nhs-blue, 10%);
}
```
