### PR TITLE
Immediate sass build

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -4,6 +4,8 @@ module.exports = function(grunt) {
   grunt.initConfig({
     pkg: grunt.file.readJSON('package.json'),
 
+    clean: ['assets/css'],
+
     nodemon: {
       dev: {
         script: 'app.js'
@@ -39,11 +41,20 @@ module.exports = function(grunt) {
 
   });
 
+  grunt.loadNpmTasks('grunt-contrib-clean');
   grunt.loadNpmTasks('grunt-nodemon');
   grunt.loadNpmTasks('grunt-contrib-sass');
   grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.loadNpmTasks('grunt-concurrent');
 
-  grunt.registerTask('default', ['concurrent:target']);
+  grunt.registerTask('generate-assets', [
+    'clean',
+    'sass'
+  ]);
+
+  grunt.registerTask('default', [
+    'generate-assets',
+    'concurrent:target'
+  ]);
 
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -16,7 +16,7 @@ module.exports = function(grunt) {
       dist: {
         options: {
           outputStyle: 'expanded',
-          sourceMap: false
+          sourceMap: true
         },
         files: {
           'assets/css/main.css': 'assets/scss/main.scss'

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -15,7 +15,8 @@ module.exports = function(grunt) {
     sass: {
       dist: {
         options: {
-          style: 'expanded'
+          outputStyle: 'expanded',
+          sourceMap: false
         },
         files: {
           'assets/css/main.css': 'assets/scss/main.scss'
@@ -43,7 +44,7 @@ module.exports = function(grunt) {
 
   grunt.loadNpmTasks('grunt-contrib-clean');
   grunt.loadNpmTasks('grunt-nodemon');
-  grunt.loadNpmTasks('grunt-contrib-sass');
+  grunt.loadNpmTasks('grunt-sass');
   grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.loadNpmTasks('grunt-concurrent');
 

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: node app.js
+web: node ./node_modules/grunt-cli/bin/grunt --gruntfile Gruntfile.js generate-assets && node server.js

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: node ./node_modules/grunt-cli/bin/grunt --gruntfile Gruntfile.js generate-assets && node server.js
+web: node ./node_modules/grunt-cli/bin/grunt --gruntfile Gruntfile.js generate-assets && node app.js

--- a/package.json
+++ b/package.json
@@ -10,13 +10,13 @@
   "dependencies": {
     "express": "^4.13.4",
     "express-nunjucks": "^0.9.6",
-    "grunt-cli": "^1.2.0",
-    "grunt-contrib-clean": "^1.0.0",
     "grunt": "^0.4.5",
+    "grunt-cli": "^1.2.0",
     "grunt-concurrent": "^2.1.0",
-    "grunt-contrib-sass": "^0.9.2",
+    "grunt-contrib-clean": "^1.0.0",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-nodemon": "^0.4.1",
+    "grunt-sass": "^1.1.0",
     "nodemon": "^1.8.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,9 +11,7 @@
     "express": "^4.13.4",
     "express-nunjucks": "^0.9.6",
     "grunt-cli": "^1.2.0",
-    "grunt-contrib-clean": "^1.0.0"
-  },
-  "devDependencies": {
+    "grunt-contrib-clean": "^1.0.0",
     "grunt": "^0.4.5",
     "grunt-concurrent": "^2.1.0",
     "grunt-contrib-sass": "^0.9.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   },
   "dependencies": {
     "express": "^4.13.4",
-    "express-nunjucks": "^0.9.6"
+    "express-nunjucks": "^0.9.6",
+    "grunt-cli": "^1.2.0",
+    "grunt-contrib-clean": "^1.0.0"
   },
   "devDependencies": {
     "grunt": "^0.4.5",


### PR DESCRIPTION
Now we're not tracking generated css files, add a Grunt task to clean out and generate css upon server startup.
Also make sure this happens on Heroku.
