### PR TITLE
Heroku config vars in local grunt workflow

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -6,6 +6,12 @@ module.exports = function(grunt) {
 
     clean: ['assets/css'],
 
+    env : {
+      heroku : {
+        src : ".env"
+      }
+    },
+
     nodemon: {
       dev: {
         script: 'app.js'
@@ -47,6 +53,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-sass');
   grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.loadNpmTasks('grunt-concurrent');
+  grunt.loadNpmTasks('grunt-env');
 
   grunt.registerTask('generate-assets', [
     'clean',
@@ -55,6 +62,7 @@ module.exports = function(grunt) {
 
   grunt.registerTask('default', [
     'generate-assets',
+    'env:heroku',
     'concurrent:target'
   ]);
 

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ Then:
 
 To stop it all: ```^c```
 
-### Feedback mechanism
+## Environment variables
 
-If you want to run ```/feedback/feedback-example``` locally, and successfully
-```POST```, you'll need to set the Heroku ```API_KEY``` config on your machine (a
-[good way](https://devcenter.heroku.com/articles/heroku-local#copy-heroku-config-vars-to-your-local-env-file)
-is with an ```.env``` file). Run the site locally with ```heroku local``` *NOT*
-the ```grunt``` command.
+Grab a team member to share environment vars with you. At the moment there are
+variables for:
+
+- Feeback example endpoint
+- Google Analytics tracking

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "grunt-concurrent": "^2.1.0",
     "grunt-contrib-clean": "^1.0.0",
     "grunt-contrib-watch": "^0.6.1",
+    "grunt-env": "^0.4.4",
     "grunt-nodemon": "^0.4.1",
     "grunt-sass": "^1.1.0",
     "moment": "^2.13.0",


### PR DESCRIPTION
Rather than running `heroku local` to use the feedback endpoint, mount the .env file in the standard Grunt workflow.
